### PR TITLE
Tweak generator

### DIFF
--- a/SourceGen/Generator.cs
+++ b/SourceGen/Generator.cs
@@ -1,7 +1,10 @@
-﻿using System.Collections.Generic;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
 
 namespace SourceGen
 {
@@ -24,7 +27,10 @@ namespace SourceGen
 
         public void Execute(GeneratorExecutionContext context)
         {
-            var names = JsonConvert.DeserializeObject<IEnumerable<string>>(context.AdditionalFiles[0].GetText().ToString(), _jsonSerializerOptions);
+            // The SonarScanner for .NET also contributes additional files so locate the data file by name
+            var additionalFile = context.AdditionalFiles.Single(x => "data.json".Equals(Path.GetFileName(x.Path), System.StringComparison.OrdinalIgnoreCase));
+            var names = JsonConvert.DeserializeObject<IEnumerable<string>>(additionalFile.GetText().ToString(), _jsonSerializerOptions);
+
             foreach (var name in names)
             {
                 string source = $@"

--- a/SourceGen/SourceGen.csproj
+++ b/SourceGen/SourceGen.csproj
@@ -11,7 +11,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" GeneratePathProperty="true" PrivateAssets="all" />
+
+    <!-- Changed the version to be the same as that used by the SonarC# analyzer -->
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" GeneratePathProperty="true" PrivateAssets="all" />
+
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
FYI with these changes, the Sonar analysis works *if* I build using `MSBuild` (see [analysis results](https://sonarcloud.io/project/issues?id=duncanp_sourceGenMSBuild&open=AXp81OE7zjNdf36hiG7H&resolved=false&types=CODE_SMELL)).

If I build using `dotnet`, I get a weird `FileNotFoundException` : `System.Security.Permissions, Version=0.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51`. No idea why.
